### PR TITLE
Fixed issue with trying to clone the "comment" nodes

### DIFF
--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -433,10 +433,16 @@ this.MutationObserver = this.MutationObserver || this.WebKitMutationObserver || 
         var top = true;
         return (function copy($target) {
             var isText = $target.nodeType === 3;
+            var isComment = $target.nodeType === 8;
             var elestruct = {
                 /** @type {Node} */
-                node: $target
+                node: $target,
+                kids: []
             };
+
+            if (isComment) {
+                return elestruct;
+            }
 
             if(config.attr && !isText && (top || config.descendents)) {
                 /**


### PR DESCRIPTION
Fixed issue with trying to clone the "comment" nodes. Extended the default element structure to clone. The possible solution for this issue: https://github.com/megawac/MutationObserver.js/issues/8
