### PR TITLE
fix typo in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Safari 6.0.5 uses a buggy `WebKitMutationObserver` (don't have a computer with S
 A polyfill for the [MutationObserver API](http://www.w3.org/TR/2013/WD-dom-20131107/#mutation-observers) ([can I use?](http://caniuse.com/mutationobserver)). The polyfill is more cause we can than should (with subtree at any rate)... It's async and uses a recursive timeout fallback (default checks changes every 30ms + runtime) instead of using the deprecated [DOM3 MutationEvents](http://www.w3.org/TR/DOM-Level-3-Events/#events-mutationevents) so theoretically can support virtually any browser.  
 
 ```sh
-$ npm install mutationobser-shim
+$ npm install mutationobserver-shim
 $ bower install MutationObserver-shim
 ```
 


### PR DESCRIPTION
There's a small typo in the npm install command, this fixes it!
