### PR TITLE
Add special check for style attribute

### DIFF
--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -199,6 +199,43 @@ window.MutationObserver = window.MutationObserver || (function(undefined) {
         };
     }
 
+    /**
+     * Checks if browser provides value for style attribute
+     *
+     * @return {boolean}
+     */
+    function checkAttributeStyleReturnsValue() {
+        var div = document.createElement("div");
+        div.style.display = "block";
+        return div.attributes.style.value !== "null";
+    }
+
+    /**
+     * Gets an attribute value
+     *
+     * @param {HTMLElement} el
+     * @param {Attr} attr
+     * @return {String} an attribute value
+     */
+    function getAttributeSimple(el, attr) {
+        return attr.value
+    }
+
+    /**
+     * Gets an attribute value with special hack for style attribute
+     *
+     * @param {HTMLElement} el
+     * @param {Attr} attr
+     * @return {String} an attribute value
+     */
+    function getAttributeWithStyleHack(el, attr) {
+        if (attr.name !== "style")
+            return attr.value;
+        return el.style.cssText;
+    }
+
+    var getAttributeValue = checkAttributeStyleReturnsValue() ? getAttributeSimple : getAttributeWithStyleHack;
+
     /* attributes + attributeFilter helpers */
 
     /**
@@ -220,7 +257,7 @@ window.MutationObserver = window.MutationObserver || (function(undefined) {
             attr = attributes[i];
             name = attr.name;
             if (!filter || has(filter, name)) {
-                if (attr.value !== $oldstate[name]) {
+                if (getAttributeValue($target, attr) !== $oldstate[name]) {
                     // The pushing is redundant but gzips very nicely
                     mutations.push(MutationRecord({
                         type: "attributes",
@@ -464,7 +501,7 @@ window.MutationObserver = window.MutationObserver || (function(undefined) {
                      */
                     elestruct.attr = reduce($target.attributes, function(memo, attr) {
                         if (!config.afilter || config.afilter[attr.name]) {
-                            memo[attr.name] = attr.value;
+                            memo[attr.name] = getAttributeValue($target, attr);
                         }
                         return memo;
                     }, {});

--- a/MutationObserver.js
+++ b/MutationObserver.js
@@ -218,7 +218,7 @@ window.MutationObserver = window.MutationObserver || (function(undefined) {
      * @return {String} an attribute value
      */
     function getAttributeSimple(el, attr) {
-        return attr.value
+        return attr.value;
     }
 
     /**


### PR DESCRIPTION
Fixes #4 

I could not test it locally because QUnit behaves strangely when I run it in IE7 or IE5 mode. But the provided solution should polyfill the incorrect behavior of style attribute. It uses **el.style.cssText**. It doesn't represent the exact value written to the HTML style attribute because it expands properties like **border** to **border-top**, **border-left**, etc... But that should be enough for modification tracking.

**NOTE**: passing element instance is required because **attr.ownerElement** returns **undefined**